### PR TITLE
fix: Add onDestroy to worker pages / Fix TodoList

### DIFF
--- a/src/components/fruitShop/Shop.svelte
+++ b/src/components/fruitShop/Shop.svelte
@@ -22,7 +22,7 @@
 			on:dragenter
 			on:dragleave
 		>
-			{#each shop.fruits as fruit, fruitIndex (fruitIndex)}
+			{#each shop.fruits as fruit, fruitIndex (fruit.id)}
 				<Fruit
 					fruit="{fruit}"
 					shop="{shop}"

--- a/src/components/fruitShop/Shop.svelte
+++ b/src/components/fruitShop/Shop.svelte
@@ -22,7 +22,7 @@
 			on:dragenter
 			on:dragleave
 		>
-			{#each shop.fruits as fruit, fruitIndex (fruit.id)}
+			{#each shop.fruits as fruit, fruitIndex (fruitIndex)}
 				<Fruit
 					fruit="{fruit}"
 					shop="{shop}"

--- a/src/components/fruitShop/fruitShopStore.ts
+++ b/src/components/fruitShop/fruitShopStore.ts
@@ -76,9 +76,12 @@ const shopsData = writable<Shop[]>(
 		const initFruit = get(fruitsData);
 		shopsData.update((shopData) =>
 			shopData.map((shop, index) => {
-				const slickIndex = { start: index * 2, end: index * 2 + 2 };
+				if (shop.fruits.length === 0) {
+					const slickIndex = { start: index * 2, end: index * 2 + 2 };
 
-				shop.fruits.push(...initFruit.slice(slickIndex.start, slickIndex.end));
+					shop.fruits.push(...initFruit.slice(slickIndex.start, slickIndex.end));
+				}
+
 				return { ...shop, fruits: shop.fruits };
 			}),
 		);

--- a/src/components/todoList/Todo.svelte
+++ b/src/components/todoList/Todo.svelte
@@ -99,7 +99,7 @@
 		bind:isNewItem="{isNewItem}"
 	/>
 
-	<div class="absolute inset-x-0 bottom-0 z-10 py-4 text-center">
+	<div class="text-center">
 		<button
 			title="Add button"
 			type="button"

--- a/src/components/todoList/TodoList.svelte
+++ b/src/components/todoList/TodoList.svelte
@@ -9,7 +9,7 @@
 	export let isNewItem: boolean;
 </script>
 
-<ul class="customScrollbar h-full w-full space-y-4 overflow-y-scroll pb-20">
+<ul class="customScrollbar h-full w-full space-y-4 overflow-y-scroll">
 	{#if todoLists && todoLists.length > 0}
 		{#each todoLists as todo (todo.id)}
 			<TodoListItem

--- a/src/pages/carouselCallWorker.svelte
+++ b/src/pages/carouselCallWorker.svelte
@@ -4,6 +4,7 @@
 <script lang="ts">
 	import type { MockGroupType } from 'src/components/carousel/carouselStore';
 	import Carousel from '../components/carousel/Carousel.svelte';
+	import { onDestroy } from 'svelte';
 
 	let count: number = 0;
 	let groups: MockGroupType[];
@@ -19,6 +20,8 @@
 	};
 
 	worker.postMessage({ min: 5, max: 20 });
+
+	onDestroy(() => worker.terminate());
 	// #endregion Web Worker - postmessage
 </script>
 

--- a/src/pages/onTuneViewer.svelte
+++ b/src/pages/onTuneViewer.svelte
@@ -19,7 +19,7 @@
 </style>
 
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { onDestroy, onMount } from 'svelte';
 	import { Header, SideNav, Footer } from '../components/onTuneViewer';
 	import type { DateTimeFormatOptions, MockHostType, ShowViewerListType } from 'src/store';
 	import { push, querystring, location } from 'svelte-spa-router';
@@ -92,6 +92,10 @@
 
 	onMount(() => {
 		showListType = $querystring?.split('=')[1] as ShowViewerListType;
+	});
+
+	onDestroy(() => {
+		worker.terminate();
 	});
 
 	const viewFilterHandler = () => push(`${$location}?view=${showListType}`);


### PR DESCRIPTION
## 변경사항에 대한 구체적인 설명
- 기존 구현 페이지 중, worker 를 사용하는 곳에도 onDestroy 추가 적용
- Todo List 하단의 추가(+) 버튼 관련 이슈 해결
- Fruit Shop 탭으로 이동할 때마다, 각 가게의 최초 과일 데이터가 복제되는 문제 해결